### PR TITLE
chore(cicd): adding additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,137 @@
+linters:
+  enable:
+    - revive
+    - sloglint
+    - godox
+    - gosec
+    - musttag
+    - nilnil
+    - goconst
+    - gocritic
+    - gofmt
+    - iface
+    - thelper
+    - tparallel
+linters-settings:
+  revive:
+    # Default: false
+    ignore-generated-header: true
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "preserveScope"
+          - "allowJump"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
+      - name: enforce-map-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
+      - name: enforce-slice-style
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "make"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
+      - name: filename-format
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+        arguments:
+          - "^[_a-z][_a-z0-9]*.go$"
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: error
+        disabled: false
+        exclude: [ "" ]
+  sloglint:
+    # Enforce using attributes only (overrides no-mixed-args, incompatible with kv-only).
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#attributes-only
+    # Default: false
+    attr-only: true
+    # Enforce using static values for log messages.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#static-messages
+    # Default: false
+    static-msg: true
+    # Enforce using constants instead of raw keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-raw-keys
+    # Default: false
+    no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#key-naming-convention
+    # Default: ""
+    key-naming-case: snake
+    # Enforce not using specific keys.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#forbidden-keys
+    # Default: []
+    forbidden-keys:
+      - time
+      - level
+      - msg
+      - source
+      - foo
+    # Enforce putting arguments on separate lines.
+    # https://github.com/go-simpler/sloglint?tab=readme-ov-file#arguments-on-separate-lines
+    # Default: false
+    args-on-sep-lines: true
+  goconst:
+    # Ignore test files.
+    # Default: false
+    ignore-tests: true
+    # Ignore when constant is not used as function argument.
+    # Default: true
+    ignore-calls: true
+    # Exclude strings matching the given regular expression.
+    # Default: ""
+    ignore-strings: ''
+  nilnil:
+    # In addition, detect opposite situation (simultaneous return of non-nil error and valid value).
+    # Default: false
+    detect-opposite: true
+    # List of return types to check.
+    # Default: ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+    checked-types:
+      - chan
+      - func
+      - iface
+      - map
+      - ptr
+      - uintptr
+      - unsafeptr
+  gocritic:
+    enable-all: true
+  gofmt:
+    # Simplify code: gofmt with `-s` option.
+    # Default: true
+    simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
+  iface:
+    # List of analyzers.
+    # Default: ["identical"]
+    enable:
+      - identical # Identifies interfaces in the same package that have identical method sets.
+      - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.

--- a/consts.go
+++ b/consts.go
@@ -1,7 +1,8 @@
 package vaulty
 
 const (
-	loggingKeyError = "err"
+	loggingKeyError      = "err"
+	loggingKeySecretName = "secret"
 
 	pathKeyTransitDecrypt = "decrypt"
 	pathKeyTransitEncrypt = "encrypt"
@@ -9,8 +10,9 @@ const (
 	TransitKeyCipherText = "ciphertext"
 	TransitKeyPlainText  = "plaintext"
 
-	envKubernetesRole  = "KUBERNETES_ROLE"
-	envKubernetesToken = "KUBERNETES_TOKEN"
+	envKubernetesRole  = "KUBERNETES_ROLE"  // nolint:gosec // This is detected as a secret
+	envKubernetesToken = "KUBERNETES_TOKEN" // nolint:gosec // This is detected as a secret
 
-	kubernetesServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	// KubernetesServiceAccountTokenPath is the path to the Kubernetes service account token.
+	kubernetesServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // nolint:gosec // This is detected as a secret
 )

--- a/helpers.go
+++ b/helpers.go
@@ -3,11 +3,12 @@ package vaulty
 import hashiVault "github.com/hashicorp/vault/api"
 
 func CipherTextFromSecret(transitEncryptSecret *hashiVault.Secret) string {
-	if transitEncryptSecret == nil {
+	switch {
+	case transitEncryptSecret == nil:
 		return ""
-	} else if transitEncryptSecret.Data == nil {
+	case transitEncryptSecret.Data == nil:
 		return ""
-	} else if transitEncryptSecret.Data[TransitKeyCipherText] == nil {
+	case transitEncryptSecret.Data[TransitKeyCipherText] == nil:
 		return ""
 	}
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -29,14 +29,14 @@ func TestNewClient(t *testing.T) {
 			name: "nil cipher text",
 			want: "",
 			input: &hashiVault.Secret{
-				Data: map[string]interface{}{},
+				Data: make(map[string]any),
 			},
 		},
 		{
 			name: "invalid cipher text",
 			want: "",
 			input: &hashiVault.Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					TransitKeyCipherText: 1,
 				},
 			},
@@ -45,7 +45,7 @@ func TestNewClient(t *testing.T) {
 			name: "valid cipher text",
 			want: "cipher text",
 			input: &hashiVault.Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					TransitKeyCipherText: "cipher text",
 				},
 			},
@@ -54,7 +54,7 @@ func TestNewClient(t *testing.T) {
 			name: "valid cipher text: empty",
 			want: "",
 			input: &hashiVault.Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					TransitKeyCipherText: "",
 				},
 			},
@@ -63,6 +63,7 @@ func TestNewClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := CipherTextFromSecret(tt.input)
 			require.Equal(t, tt.want, got)
 		})

--- a/renewals.go
+++ b/renewals.go
@@ -34,7 +34,7 @@ const (
 //
 // ref: https://www.vaultproject.io/docs/enterprise/consistency#vault-1-7-mitigations
 func RenewLease(ctx context.Context, client ClientHandler, name string, credentials *hashiVault.Secret, renewFunc RenewalFunc) error {
-	slog.Debug("renewing lease", slog.String("secret", name))
+	slog.Debug("renewing lease", slog.String(loggingKeySecretName, name))
 
 	currentCreds := credentials
 
@@ -44,7 +44,7 @@ func RenewLease(ctx context.Context, client ClientHandler, name string, credenti
 			return fmt.Errorf("unable to renew lease: %w", err)
 		} else if res&exitRequested != 0 {
 			// Context was cancelled. Program is exiting.
-			slog.Debug("exit requested", slog.String("secret", name))
+			slog.Debug("exit requested", slog.String(loggingKeySecretName, name))
 			return nil
 		}
 
@@ -61,7 +61,7 @@ func RenewLease(ctx context.Context, client ClientHandler, name string, credenti
 			return fmt.Errorf("unable to handle watcher result: %w", err)
 		}
 
-		slog.Info("lease renewed", slog.String("secret", name))
+		slog.Info("lease renewed", slog.String(loggingKeySecretName, name))
 	}
 }
 

--- a/repositories/connect.go
+++ b/repositories/connect.go
@@ -37,11 +37,12 @@ func NewDatabaseConnector(opts ...ConnectionOption) (DatabaseConnector, error) {
 		c.ctx = context.Background()
 	}
 
-	if c.client == nil {
+	switch {
+	case c.client == nil:
 		return nil, errors.New("no vault client provided")
-	} else if c.vip == nil {
+	case c.vip == nil:
 		return nil, errors.New("no viper configuration provided")
-	} else if c.currentSecrets == nil {
+	case c.currentSecrets == nil:
 		return nil, errors.New("no current secrets provided")
 	}
 

--- a/repositories/database.go
+++ b/repositories/database.go
@@ -12,14 +12,14 @@ import (
 
 type Database struct {
 	*sqlx.DB
-	*sync.RWMutex
+	mx *sync.RWMutex
 }
 
 // NewDatabase establishes a database connection with the given Vault credentials
 func NewDatabase(db *sqlx.DB) *Database {
 	return &Database{
-		DB:      db,
-		RWMutex: new(sync.RWMutex),
+		DB: db,
+		mx: new(sync.RWMutex),
 	}
 }
 
@@ -72,8 +72,8 @@ func (d *Database) closeReplaceConnection(newDb *sqlx.DB) {
 func (d *Database) Close() error {
 	slog.Debug("Acquiring lock to close database connection")
 
-	d.Lock()
-	defer d.Unlock()
+	d.mx.Lock()
+	defer d.mx.Unlock()
 
 	slog.Debug("Lock acquired to close database connection")
 
@@ -85,8 +85,8 @@ func (d *Database) Close() error {
 }
 
 func (d *Database) PingContext(ctx context.Context) error {
-	d.RLock()
-	defer d.RUnlock()
+	d.mx.RLock()
+	defer d.mx.RUnlock()
 
 	return d.DB.PingContext(ctx)
 }


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes several changes to improve code quality, enhance logging, and update testing practices. The most important changes are the addition of new linters and their configurations, improvements to logging key names, and updates to testing for parallel execution.

### Code Quality Improvements:
* [`.golangci.yaml`](diffhunk://#diff-9917ddc9f1c3304218f7269265b746d997c5c0615478177b5fceecd33ef47cb5R1-R137): Added new linters such as `revive`, `sloglint`, `godox`, `gosec`, and others, along with their specific settings to enforce coding standards and best practices.

### Logging Enhancements:
* [`consts.go`](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566R5-R17): Added `loggingKeySecretName` for consistent logging key usage and added `nolint:gosec` comments to specific constants.
* [`renewals.go`](diffhunk://#diff-5103bbeaab5a529fa318992ba07046898afd906f5952bacd63ff008aab8d2de1L37-R37): Updated logging statements to use `loggingKeySecretName` instead of hardcoded string literals. [[1]](diffhunk://#diff-5103bbeaab5a529fa318992ba07046898afd906f5952bacd63ff008aab8d2de1L37-R37) [[2]](diffhunk://#diff-5103bbeaab5a529fa318992ba07046898afd906f5952bacd63ff008aab8d2de1L47-R47) [[3]](diffhunk://#diff-5103bbeaab5a529fa318992ba07046898afd906f5952bacd63ff008aab8d2de1L64-R64)

### Testing Improvements:
* [`helpers_test.go`](diffhunk://#diff-62f46d82044a129997b958c0f7eb6a95038395d337176418d3dffae98d9332d1L32-R39): Updated test cases to use `map[string]any` instead of `map[string]interface{}` and added `t.Parallel()` to run tests in parallel for better performance. [[1]](diffhunk://#diff-62f46d82044a129997b958c0f7eb6a95038395d337176418d3dffae98d9332d1L32-R39) [[2]](diffhunk://#diff-62f46d82044a129997b958c0f7eb6a95038395d337176418d3dffae98d9332d1L48-R48) [[3]](diffhunk://#diff-62f46d82044a129997b958c0f7eb6a95038395d337176418d3dffae98d9332d1L57-R57) [[4]](diffhunk://#diff-62f46d82044a129997b958c0f7eb6a95038395d337176418d3dffae98d9332d1R66)

### Code Refactoring:
* [`helpers.go`](diffhunk://#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9L6-R11): Refactored `CipherTextFromSecret` function to use a `switch` statement for improved readability.
* [`repositories/connect.go`](diffhunk://#diff-f7b9d2de54a148190477a9a7dde258c516e9aa9399050aed1fc2d7d15b64e631L40-R45): Refactored `NewDatabaseConnector` function to use a `switch` statement for better clarity.
* [`repositories/database.go`](diffhunk://#diff-95ccdca53a8692e11e26ec7fc8ac3e4851c41510b410a0f5b1beeb5072d77f08L15-R22): Replaced embedded `sync.RWMutex` with a named field `mx` for better code clarity and maintainability. [[1]](diffhunk://#diff-95ccdca53a8692e11e26ec7fc8ac3e4851c41510b410a0f5b1beeb5072d77f08L15-R22) [[2]](diffhunk://#diff-95ccdca53a8692e11e26ec7fc8ac3e4851c41510b410a0f5b1beeb5072d77f08L75-R76) [[3]](diffhunk://#diff-95ccdca53a8692e11e26ec7fc8ac3e4851c41510b410a0f5b1beeb5072d77f08L88-R89)