### PR TITLE
chore(cicd): removing workflow redundant steps

### DIFF
--- a/.github/workflows/ci-code-approval.yml
+++ b/.github/workflows/ci-code-approval.yml
@@ -38,11 +38,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -63,11 +58,6 @@ jobs:
           go-version: ${{ vars.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
 
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
-
       - name: Make
         run: make pr-approval
 
@@ -85,11 +75,6 @@ jobs:
         with:
           go-version: ${{ vars.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
-
-      - name: "Configure git for private modules"
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x:${GITHUB_API_TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: "Run Code Generation"
         run: go generate ./...


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request focuses on simplifying the CI workflow by removing redundant steps related to configuring git for private modules in the `ci-code-approval.yml` file.

Simplification of CI workflow:

* [`.github/workflows/ci-code-approval.yml`](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L41-L45): Removed the step for configuring git for private modules across multiple job sections. [[1]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L41-L45) [[2]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L66-L70) [[3]](diffhunk://#diff-4c8bb8f5cf698728ae107fc054fb2460fb0be2c349f4c5353577be9c6add0c50L89-L93)