### PR TITLE
fix(vsql): using schema key over name

### DIFF
--- a/vsql/consts.go
+++ b/vsql/consts.go
@@ -9,7 +9,7 @@ const (
 	configKeyVaultDatabaseRole = configKeyVaultDatabase + ".role"
 	configKeyVaultDatabasePath = configKeyVaultDatabase + ".path"
 	configKeyDatabaseHost      = configKeyDatabase + ".host"
-	configKeyDatabaseName      = configKeyDatabase + ".name"
+	configKeyDatabaseName      = configKeyDatabase + ".schema"
 
 	secretKeyDatabaseUsername = "username"
 	secretKeyDatabasePassword = "password"

--- a/watcher.go
+++ b/watcher.go
@@ -27,7 +27,7 @@ func monitorWatcher(ctx context.Context, l *slog.Logger, token string, watcher *
 			// RenewCh is a channel that receives a message when a successful
 			// renewal takes place and includes metadata about the renewal.
 		case info := <-watcher.RenewCh():
-			l.Info("renewal successful",
+			l.Debug("renewal successful",
 				slog.String(loggingKeyRenewedAt, info.RenewedAt.String()),
 				slog.String(loggingKeySecretName, token),
 				slog.String(loggingKeyLeaseDuration, fmt.Sprintf("%ds", info.Secret.LeaseDuration)),


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes two key changes: a modification to a configuration constant in `vsql/consts.go` and an update to the logging level in `watcher.go`. These changes improve clarity and adjust the verbosity of logging for secret renewal events.

### Configuration Changes:
* [`vsql/consts.go`](diffhunk://#diff-ff5481636d8362865908bdf80a55b905d219327f5720d5f4d22d45589928957aL12-R12): Updated the `configKeyDatabaseName` constant to use `.schema` instead of `.name`, reflecting a change in the configuration's intended purpose.

### Logging Adjustments:
* [`watcher.go`](diffhunk://#diff-7ad556f6b178c41713de2fe275d86d612eddbbe69324d95f5b9eb7217d69e124L30-R30): Changed the logging level for successful renewal messages from `Info` to `Debug`, reducing log verbosity for this event.