### PR TITLE
chore(options): Updating client opts to allow for downard api functionality

### DIFF
--- a/auth_kubernetes.go
+++ b/auth_kubernetes.go
@@ -31,6 +31,5 @@ func kubernetesLogin(client *hashiVault.Client, role string, token auth.LoginOpt
 	}
 
 	client.SetToken(authInfo.Auth.ClientToken)
-
 	return authInfo, nil
 }

--- a/client.go
+++ b/client.go
@@ -61,7 +61,9 @@ func NewClient(opts ...ClientOption) (Client, error) {
 	}
 
 	for _, opt := range opts {
-		opt(c)
+		if err := opt(c); err != nil {
+			return nil, fmt.Errorf("unable to apply client option: %w", err)
+		}
 	}
 
 	if c.ctx == nil {

--- a/client_opts.go
+++ b/client_opts.go
@@ -35,6 +35,7 @@ func WithGeneratedVaultClient(vaultAddress string) ClientOption {
 	return WithAddr(vaultAddress)
 }
 
+// WithAddr sets the address for the client.
 func WithAddr(addr string) ClientOption {
 	return func(c *client) error {
 		c.config.Address = addr
@@ -42,6 +43,7 @@ func WithAddr(addr string) ClientOption {
 	}
 }
 
+// WithConfig sets the config for the client.
 func WithConfig(config *hashiVault.Config) ClientOption {
 	return func(c *client) error {
 		c.config = config
@@ -49,6 +51,7 @@ func WithConfig(config *hashiVault.Config) ClientOption {
 	}
 }
 
+// WithTokenAuth sets the token for the client.
 func WithTokenAuth(token string) ClientOption {
 	return func(c *client) error {
 		if token == "" {
@@ -62,6 +65,7 @@ func WithTokenAuth(token string) ClientOption {
 	}
 }
 
+// WithAppRoleAuth sets the AppRole authentication method for the client.
 func WithAppRoleAuth(roleID, secretID string) ClientOption {
 	return func(c *client) error {
 		if roleID == "" {
@@ -82,6 +86,7 @@ func WithAppRoleAuth(roleID, secretID string) ClientOption {
 	}
 }
 
+// WithUserPassAuth sets the UserPass authentication method for the client.
 func WithUserPassAuth(username, password string) ClientOption {
 	return func(c *client) error {
 		if username == "" {
@@ -102,6 +107,7 @@ func WithUserPassAuth(username, password string) ClientOption {
 	}
 }
 
+// WithKvv2Mount sets the KVv2 mount point for the client.
 func WithKvv2Mount(mount string) ClientOption {
 	return func(c *client) error {
 		c.kvv2Mount = mount
@@ -109,6 +115,7 @@ func WithKvv2Mount(mount string) ClientOption {
 	}
 }
 
+// WithKubernetesServiceAccountAuth sets the Kubernetes authentication method for the client using a service account.
 func WithKubernetesServiceAccountAuth(roleName string) ClientOption {
 	return func(c *client) error {
 		if roleName == "" {
@@ -129,6 +136,7 @@ func WithKubernetesServiceAccountAuth(roleName string) ClientOption {
 	}
 }
 
+// WithKubernetesAuthFromEnv sets the Kubernetes authentication method for the client using a service account from environment variables.
 func WithKubernetesAuthFromEnv() ClientOption {
 	return func(c *client) error {
 		roleFromEnv := os.Getenv(envServiceAccountName)
@@ -140,6 +148,7 @@ func WithKubernetesAuthFromEnv() ClientOption {
 	}
 }
 
+// WithKubernetesAuth sets the Kubernetes authentication method for the client using the role and token provided.
 func WithKubernetesAuth(role, token string) ClientOption {
 	return func(c *client) error {
 		if role == "" {

--- a/client_opts.go
+++ b/client_opts.go
@@ -2,7 +2,7 @@ package vaulty
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
 	"os"
 
@@ -10,19 +10,21 @@ import (
 	kubernetesAuth "github.com/hashicorp/vault/api/auth/kubernetes"
 )
 
-type ClientOption func(c *client)
+type ClientOption func(c *client) error
 
 // WithContext sets the context for the client.
 func WithContext(ctx context.Context) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
 		c.ctx = ctx
+		return nil
 	}
 }
 
 // WithLogger sets the logger for the client.
 func WithLogger(l *slog.Logger) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
 		c.l = l
+		return nil
 	}
 }
 
@@ -34,27 +36,40 @@ func WithGeneratedVaultClient(vaultAddress string) ClientOption {
 }
 
 func WithAddr(addr string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
 		c.config.Address = addr
+		return nil
 	}
 }
 
 func WithConfig(config *hashiVault.Config) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
 		c.config = config
+		return nil
 	}
 }
 
 func WithTokenAuth(token string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
+		if token == "" {
+			return errors.New("token is empty")
+		}
+
 		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
 			return tokenLogin(v, token)
 		}
+		return nil
 	}
 }
 
 func WithAppRoleAuth(roleID, secretID string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
+		if roleID == "" {
+			return errors.New("roleID is empty")
+		} else if secretID == "" {
+			return errors.New("secretID is empty")
+		}
+
 		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
 			sec, err := appRoleLogin(v, roleID, secretID)
 			if err != nil {
@@ -63,11 +78,18 @@ func WithAppRoleAuth(roleID, secretID string) ClientOption {
 			go c.renewAuthInfo()
 			return sec, nil
 		}
+		return nil
 	}
 }
 
 func WithUserPassAuth(username, password string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
+		if username == "" {
+			return errors.New("username is empty")
+		} else if password == "" {
+			return errors.New("password is empty")
+		}
+
 		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
 			sec, err := userPassLogin(v, username, password)
 			if err != nil {
@@ -76,24 +98,25 @@ func WithUserPassAuth(username, password string) ClientOption {
 			go c.renewAuthInfo()
 			return sec, nil
 		}
+		return nil
 	}
 }
 
 func WithKvv2Mount(mount string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
 		c.kvv2Mount = mount
+		return nil
 	}
 }
 
-func WithKubernetesAuthDefault() ClientOption {
-	return func(c *client) {
-		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
-			role := os.Getenv(envKubernetesRole)
-			if role == "" {
-				return nil, fmt.Errorf("%s environment variable not set", envKubernetesRole)
-			}
+func WithKubernetesAuthDefault(roleName string) ClientOption {
+	return func(c *client) error {
+		if roleName == "" {
+			return errors.New("role name is empty")
+		}
 
-			sec, err := kubernetesLogin(v, role, kubernetesAuth.WithServiceAccountTokenPath(kubernetesServiceAccountTokenPath))
+		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
+			sec, err := kubernetesLogin(v, roleName, kubernetesAuth.WithServiceAccountTokenPath(kubernetesServiceAccountTokenPath))
 			if err != nil {
 				return nil, err
 			}
@@ -102,31 +125,29 @@ func WithKubernetesAuthDefault() ClientOption {
 
 			return sec, nil
 		}
+		return nil
 	}
 }
 
 func WithKubernetesAuthFromEnv() ClientOption {
-	return func(c *client) {
-		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
-			role := os.Getenv(envKubernetesRole)
-			if role == "" {
-				return nil, fmt.Errorf("%s environment variable not set", envKubernetesRole)
-			}
-
-			sec, err := kubernetesLogin(v, role, kubernetesAuth.WithServiceAccountTokenEnv(envKubernetesToken))
-			if err != nil {
-				return nil, err
-			}
-
-			go c.renewAuthInfo()
-
-			return sec, nil
+	return func(c *client) error {
+		roleFromEnv := os.Getenv(envServiceAccountName)
+		if roleFromEnv == "" {
+			return errors.New("role name is not set in environment variable")
 		}
+
+		return WithKubernetesAuthDefault(roleFromEnv)(c)
 	}
 }
 
 func WithKubernetesAuth(role, token string) ClientOption {
-	return func(c *client) {
+	return func(c *client) error {
+		if role == "" {
+			return errors.New("role name is empty")
+		} else if token == "" {
+			return errors.New("token is empty")
+		}
+
 		c.auth = func(v *hashiVault.Client) (*hashiVault.Secret, error) {
 			sec, err := kubernetesLogin(v, role, kubernetesAuth.WithServiceAccountToken(token))
 			if err != nil {
@@ -137,5 +158,6 @@ func WithKubernetesAuth(role, token string) ClientOption {
 
 			return sec, nil
 		}
+		return nil
 	}
 }

--- a/client_opts.go
+++ b/client_opts.go
@@ -141,7 +141,7 @@ func WithKubernetesAuthFromEnv() ClientOption {
 	return func(c *client) error {
 		roleFromEnv := os.Getenv(envServiceAccountName)
 		if roleFromEnv == "" {
-			return errors.New("role name is not set in environment variable")
+			return errors.New("role name is not set in environment variable " + envServiceAccountName)
 		}
 
 		return WithKubernetesServiceAccountAuth(roleFromEnv)(c)

--- a/client_opts.go
+++ b/client_opts.go
@@ -109,7 +109,7 @@ func WithKvv2Mount(mount string) ClientOption {
 	}
 }
 
-func WithKubernetesAuthDefault(roleName string) ClientOption {
+func WithKubernetesServiceAccountAuth(roleName string) ClientOption {
 	return func(c *client) error {
 		if roleName == "" {
 			return errors.New("role name is empty")
@@ -136,7 +136,7 @@ func WithKubernetesAuthFromEnv() ClientOption {
 			return errors.New("role name is not set in environment variable")
 		}
 
-		return WithKubernetesAuthDefault(roleFromEnv)(c)
+		return WithKubernetesServiceAccountAuth(roleFromEnv)(c)
 	}
 }
 

--- a/consts.go
+++ b/consts.go
@@ -16,7 +16,6 @@ const (
 	TransitKeyPlainText  = "plaintext"
 
 	envServiceAccountName = "SERVICE_ACCOUNT_NAME" // nolint:gosec // This is detected as a secret
-	envKubernetesToken    = "KUBERNETES_TOKEN"     // nolint:gosec // This is detected as a secret
 
 	// KubernetesServiceAccountTokenPath is the path to the Kubernetes service account token.
 	kubernetesServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // nolint:gosec // This is detected as a secret

--- a/consts.go
+++ b/consts.go
@@ -15,8 +15,8 @@ const (
 	TransitKeyCipherText = "ciphertext"
 	TransitKeyPlainText  = "plaintext"
 
-	envKubernetesRole  = "KUBERNETES_ROLE"  // nolint:gosec // This is detected as a secret
-	envKubernetesToken = "KUBERNETES_TOKEN" // nolint:gosec // This is detected as a secret
+	envServiceAccountName = "SERVICE_ACCOUNT_NAME" // nolint:gosec // This is detected as a secret
+	envKubernetesToken    = "KUBERNETES_TOKEN"     // nolint:gosec // This is detected as a secret
 
 	// KubernetesServiceAccountTokenPath is the path to the Kubernetes service account token.
 	kubernetesServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" // nolint:gosec // This is detected as a secret

--- a/mock_ClientOption.go
+++ b/mock_ClientOption.go
@@ -10,8 +10,21 @@ type MockClientOption struct {
 }
 
 // Execute provides a mock function with given fields: c
-func (_m *MockClientOption) Execute(c *client) {
-	_m.Called(c)
+func (_m *MockClientOption) Execute(c *client) error {
+	ret := _m.Called(c)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Execute")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*client) error); ok {
+		r0 = rf(c)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // NewMockClientOption creates a new instance of MockClientOption. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several improvements to the `vaulty` package, focusing on enhancing error handling, improving the flexibility of Kubernetes authentication, and refactoring the client option functions for better robustness and clarity.

### Error Handling Improvements:
* Modified the `ClientOption` type to return an error, enabling validation and error reporting during client option application. (`client_opts.go`, `[client_opts.goL5-R27](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dL5-R27)`)
* Added error checks to `WithTokenAuth`, `WithAppRoleAuth`, `WithUserPassAuth`, and other client option functions to validate input parameters (e.g., checking for empty tokens, role IDs, or usernames). (`client_opts.go`, `[[1]](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dL37-R72)`, `[[2]](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR81-R92)`, `[[3]](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR101-R119)`, `[[4]](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR128-R150)`, `[[5]](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR161)`)
* Updated the `NewClient` function to handle errors returned by client options, ensuring invalid configurations are caught early. (`client.go`, `[client.goL64-R66](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL64-R66)`)

### Kubernetes Authentication Enhancements:
* Replaced the `WithKubernetesAuthDefault` function to accept a `roleName` parameter instead of relying on an environment variable, improving flexibility. (`client_opts.go`, `[client_opts.goR101-R119](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR101-R119)`)
* Refactored `WithKubernetesAuthFromEnv` to use the new `WithKubernetesAuthDefault` function, simplifying its implementation. (`client_opts.go`, `[client_opts.goR128-R150](diffhunk://#diff-684a8ba96ce98656b5618665b8eca636e3d2dd534866d917d1ae04f2fa08509dR128-R150)`)
* Renamed `envKubernetesRole` to `envServiceAccountName` for better clarity and consistency. (`consts.go`, `[consts.goL18-R18](diffhunk://#diff-f0067949ae0f48685cd310e00ccaf0c72d02048ccc6aeb0a862cd30b81e5e566L18-R18)`)

### Minor Refactorings:
* Removed an unnecessary blank line in the `kubernetesLogin` function. (`auth_kubernetes.go`, `[auth_kubernetes.goL34](diffhunk://#diff-ccbecf2f1003e653b4e48f23e31c6c11f8492f2b66edb0a685ce09ea013db779L34)`)